### PR TITLE
Use shared-modules for SDL2 and libdecor, permissions update

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/net.supertuxkart.SuperTuxKart.json
+++ b/net.supertuxkart.SuperTuxKart.json
@@ -9,13 +9,13 @@
     "rename-icon": "supertuxkart",
     "command": "supertuxkart",
     "finish-args": [
-	"--socket=wayland",
+        "--socket=wayland",
         "--socket=fallback-x11",
-	"--share=ipc",
+        "--share=ipc",
         "--socket=pulseaudio",
         "--share=network",
         "--device=all",
-	"--filesystem=xdg-run/app/com.discordapp.Discord:create"
+        "--filesystem=xdg-run/app/com.discordapp.Discord:create"
     ],
     "build-options" : {
         "env": {
@@ -28,7 +28,7 @@
                 "/share/vala",
                 "*.la", "*.a"],
     "modules": [
-	"shared-modules/SDL2/SDL2-2.26.1-with-libdecor.json",
+        "shared-modules/SDL2/SDL2-2.26.1-with-libdecor.json",
         {
             "name": "libopenglrecorder",
             "buildsystem": "cmake",

--- a/net.supertuxkart.SuperTuxKart.json
+++ b/net.supertuxkart.SuperTuxKart.json
@@ -9,9 +9,9 @@
     "rename-icon": "supertuxkart",
     "command": "supertuxkart",
     "finish-args": [
-        "--share=ipc",
+	"--socket=wayland",
         "--socket=fallback-x11",
-        "--socket=wayland",
+	"--share=ipc",
         "--socket=pulseaudio",
         "--share=network",
         "--device=all"
@@ -27,6 +27,7 @@
                 "/share/vala",
                 "*.la", "*.a"],
     "modules": [
+	"shared-modules/SDL2/SDL2-2.26.1-with-libdecor.json",
         {
             "name": "libopenglrecorder",
             "buildsystem": "cmake",

--- a/net.supertuxkart.SuperTuxKart.json
+++ b/net.supertuxkart.SuperTuxKart.json
@@ -14,7 +14,8 @@
 	"--share=ipc",
         "--socket=pulseaudio",
         "--share=network",
-        "--device=all"
+        "--device=all",
+	"--filesystem=xdg-run/app/com.discordapp.Discord:create"
     ],
     "build-options" : {
         "env": {


### PR DESCRIPTION
Currently, SuperTuxCart uses the runtime-provided SDL2 which doesn't provide libdecor. Therefore, it doesn't draw its own window decorations on Wayland compositors that don't implement the xdg-decoration protocol. This fixes that issue. I also reordered the permissions a bit to be a bit cleaner.

Closes https://github.com/flathub/net.supertuxkart.SuperTuxKart/issues/23