### PR TITLE
Backport fix for AI karts in battle mode

### DIFF
--- a/fix-ai-karts.patch
+++ b/fix-ai-karts.patch
@@ -1,0 +1,36 @@
+From 8544f19b59208ae93fc3db0cf41bd386c6aefbcb Mon Sep 17 00:00:00 2001
+From: Benau <Benau@users.noreply.github.com>
+Date: Thu, 5 Jan 2023 10:33:39 +0800
+Subject: [PATCH] Fix #4834
+
+---
+ src/race/race_manager.hpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/race/race_manager.hpp b/src/race/race_manager.hpp
+index 67a6ebd5016..63c39f0f677 100644
+--- a/src/race/race_manager.hpp
++++ b/src/race/race_manager.hpp
+@@ -28,6 +28,7 @@
+ 
+ #include <vector>
+ #include <algorithm>
++#include <cassert>
+ #include <string>
+ 
+ #include "network/remote_kart_info.hpp"
+@@ -644,11 +645,14 @@ class RaceManager
+     // ----------------------------------------------------------------------------------------
+     int getKartLocalPlayerId(int k) const
+     {
++        assert(k < (int)m_kart_status.size());
+         return m_kart_status[k].m_local_player_id;
+     }   // getKartLocalPlayerId
+     // ----------------------------------------------------------------------------------------
+     int getKartGlobalPlayerId(int k) const
+     {
++        if (k >= (int)m_kart_status.size())
++            return -1;
+         return m_kart_status[k].m_global_player_id;
+     }   // getKartGlobalPlayerId
+     // ----------------------------------------------------------------------------------------

--- a/net.supertuxkart.SuperTuxKart.json
+++ b/net.supertuxkart.SuperTuxKart.json
@@ -64,6 +64,10 @@
                 {
                     "type": "patch",
                     "path": "fix-gcc13-build.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "fix-ai-karts.patch"
                 }
             ]
         }


### PR DESCRIPTION
Should fix #33. This was trivial, I just found the commit in question on GitHub (https://github.com/supertuxkart/stk-code/commit/8544f19b59208ae93fc3db0cf41bd386c6aefbcb) and then inserted `.patch` at the end of the commit URL. Then I just forked this repo and added the patch itself as well as a reference to it in the manifest.

CC @AsciiWolf and @ADBeveridge.